### PR TITLE
feat: add docker entry point for `auth` app

### DIFF
--- a/apps/auth/Dockerfile
+++ b/apps/auth/Dockerfile
@@ -1,0 +1,42 @@
+FROM rust:latest AS builder
+
+WORKDIR /usr/src/auth
+
+COPY apps/auth/Cargo.toml Cargo.lock ./
+COPY apps/auth/src ./src
+COPY .env ./
+
+# Create the environment file inside the container with needed variables
+RUN set -o allexport \
+      && . /usr/src/auth/.env \
+      && set +o allexport \
+      && mkdir -p /app \
+      && echo "DB_POSTGRES_USER=$DB_POSTGRES_USER" >> /app/.env \
+      && echo "DB_POSTGRES_PASS=$DB_POSTGRES_PASS" >> /app/.env \
+      && echo "DB_POSTGRES_HOST=$DB_POSTGRES_HOST" >> /app/.env \
+      && echo "DB_POSTGRES_PORT=$DB_POSTGRES_PORT" >> /app/.env \
+      && echo "DB_POSTGRES_NAME=$DB_POSTGRES_NAME" >> /app/.env \
+      && echo "AUTH_JWT_SECRET=$AUTH_JWT_SECRET" >> /app/.env \
+      && echo "AUTH_DEV_MODE=$AUTH_DEV_MODE" >> /app/.env \
+      && echo "AUTH_PORT=$AUTH_PORT" >> /app/.env
+
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+WORKDIR /app
+
+# Install only runtime dependencies for Actix (e.g., OpenSSL)
+RUN apt-get update && \
+    apt-get install -y libssl-dev ca-certificates && \
+    rm -rf /var/lib/apt/lists/* :contentReference[oaicite:4]{index=4}
+
+# copy everything from builder
+# COPY --from=builder /usr/src/auth/ /usr/src/auth/
+
+# Copy the compiled binary from builder
+COPY --from=builder /usr/src/auth/target/release/auth   /usr/local/bin/auth
+COPY --from=builder /app/.env                           .env
+
+EXPOSE 3000
+
+CMD ["auth"]

--- a/apps/auth/docker-compose.yml
+++ b/apps/auth/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  app:
+    container_name: api6_auth
+    build:
+      context: ../../.
+      dockerfile: apps/auth/Dockerfile
+    ports:
+      - '3000:3000'
+    networks:
+      - db_api6
+
+networks:
+  db_api6:
+    external: true

--- a/apps/auth/project.json
+++ b/apps/auth/project.json
@@ -4,6 +4,18 @@
   "projectType": "application",
   "sourceRoot": "apps/auth/src",
   "targets": {
+    "serve-docker": {
+      "executor": "nx:run-commands",
+      "defaultConfiguration": "foreground",
+      "configurations": {
+        "detached": {
+          "command": "docker-compose -f {projectRoot}/docker-compose.yml up -d --build"
+        },
+        "foreground": {
+          "command": "docker-compose -f {projectRoot}/docker-compose.yml up --build"
+        }
+      }
+    },
     "serve": {
       "executor": "@monodon/rust:run",
       "outputs": ["{options.target-dir}"],

--- a/apps/auth/src/infra/db.rs
+++ b/apps/auth/src/infra/db.rs
@@ -12,6 +12,8 @@ pub async fn create_seaorm_connection(config: &DatabaseConfig) -> DatabaseConnec
       config.db_name,
     );
 
+    println!("Connecting to database at {}", db_url);
+
     match Database::connect(&db_url).await {
         Ok(connection) => {
             println!("Connected to database at {}", db_url);


### PR DESCRIPTION
nota: setar `DB_POSTGRES_HOST` como `api6_postgres` (nome do container postgres) no `.env` (raiz do monorepo):

```env
DB_POSTGRES_HOST=api6_postgres
```

demais variáveis podem ser mantidas com o valor encontrado em `.env.example`